### PR TITLE
[DCP-1349] DX Lab: Art Index site: fix typo in artist name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "dxlab-art-index",
       "version": "0.2.6",
       "license": "ISC",
       "dependencies": {
@@ -76,7 +77,7 @@
         "webpack": "^4.41.6"
       },
       "engines": {
-        "node": "14.x"
+        "node": "18.x"
       }
     },
     "node_modules/@ampproject/toolbox-core": {

--- a/public/data/artists.csv
+++ b/public/data/artists.csv
@@ -731,7 +731,7 @@ Combes",51,male,,https://digital.sl.nsw.gov.au/delivery/StreamGate?dps_dvs=16015
 2746,Douglas G,Salier,4,male,,,,,,
 750,George H (Junior),Harvey,4,male,,,,,,
 1970,Knud Geelmuyden,Bull,4,male,,,,,,
-2753,Jan Hendrick,Scheltema,4,male,,,,,,
+2753,Jan Hendrik,Scheltema,4,male,,,,,,
 2417,Barnett,Johnson,4,male,,,,,,
 438,William,Kerr,4,male,,,,,,
 183,E,Bartley,4,female,,,,,,


### PR DESCRIPTION
# [DCP-1349](https://statelibrarynsw.atlassian.net/browse/DCP-1349)

* DX Lab: Art Index site:
  * fix typo, correct name is "Jan Hendrik Scheltema"

# Screenshots

## Before fix:

![image](https://github.com/user-attachments/assets/9c8da790-28ad-4b8b-9de9-ed4932838d0c)


## After fix:

![image](https://github.com/user-attachments/assets/2dce1d62-002a-4aba-b3a6-214c2b681e93)


[DCP-1349]: https://statelibrarynsw.atlassian.net/browse/DCP-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ